### PR TITLE
Correcion de receta

### DIFF
--- a/resources/views/consulta/pdfCompleto.blade.php
+++ b/resources/views/consulta/pdfCompleto.blade.php
@@ -93,7 +93,7 @@
                 <div>
                     <p id="fila" style="margin-top: 125px; padding-left: 205px;">{!! $consulta->diagnostico ? e($consulta->diagnostico) : '&nbsp;' !!}</p>
                 </div>
-                <div style="margin-top: 115px; padding-left: 205px;">
+                <div style="margin-top: 115px; padding-left: 200px;max-width: 1200px">
                     @foreach ($recetas as $key => $receta)
                         <p  id="fila" style="margin-top: 20px; padding-left:-5px;">{{$key+1}}. {{$receta->medicamento}}  #{{$receta->cantidad}} </p>
                         <p  id="bodyMed" style="margin-top: -20px; padding-left:25px;">{{$receta->dosis}} </p>


### PR DESCRIPTION
La receta teenia error al generarse, sobresalia del margen de la imagen. se corrige pdfCompleto.blade.php para colocar en la etiqueta del body un máximo de ancho html para el pdf generado